### PR TITLE
Use artist field from iTunes when the album artist is empty

### DIFF
--- a/MusicaController.m
+++ b/MusicaController.m
@@ -963,6 +963,10 @@
 		[theTrack setGenre:((ETTrack*)track).genre];
 		[theTrack setLength:[NSNumber numberWithInt:((ETTrack*)track).duration]];
 		[player setRatingNumber:[NSNumber numberWithInt:((ETTrack*)track).rating]];
+        
+        if ([[track albumArtist] isEqualToString:@""]) {
+            [theTrack setArtist:((ETTrack*)track).artist];
+        }
 	}
     if ([[track className] isEqualToString:@"InstacastEpisode"]) {
         [theTrack setTitle:((InstacastEpisode*)track).title];


### PR DESCRIPTION
Because sometimes the album artist isn't filled in iTunes

(I'm not an Obj-C guy so feel free to recode this properly)
